### PR TITLE
Fix append row

### DIFF
--- a/cox/store.py
+++ b/cox/store.py
@@ -413,7 +413,7 @@ class Table():
             nrows = 0
 
         df.index += nrows
-        self._HDFStore.append(self._name, df, table=True)
+        self._HDFStore.append(self._name, df, format='table')
 
         if not self._has_initialized:
              self._initialize_nonempty_table()


### PR DESCRIPTION
**Error:**  When running `store['my_table'].append_row(...)` I was getting the error:
![Image](https://user-images.githubusercontent.com/18227298/77829037-0e411c00-7128-11ea-8573-7101423ea03e.png)

**Possible cause**: I suspect that the error is because you are using an older version of Pandas. In the latest version of Pandas, the documentation shows that the field `table=True` was replaced by `format='table'` [docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.HDFStore.append.html)