### PR TITLE
Made changes to the parameters class, so that python objects can be a…

### DIFF
--- a/cox/utils.py
+++ b/cox/utils.py
@@ -5,6 +5,7 @@ import os
 import dill as pickle
 import codecs
 import itertools
+import pprint 
 
 def has_tensorboard(dirname):
     '''
@@ -126,7 +127,8 @@ class Parameters():
         return len(self.params)
 
     def __str__(self):
-        return json.dumps(self.params, indent=2)
+        pp = pprint.PrettyPrinter()
+        return pp.pformat(self.params)
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
…dded to args and printed afterwards. I was having trouble passing in an oracle into the args dictionary and could not print the args dictionary, because it was using json.dumps (requires all included objects to be serialized). I changed it so that the print functionality uses pprint instead.